### PR TITLE
'async' is a reserved word in Python >= 3.7

### DIFF
--- a/train_arm.py
+++ b/train_arm.py
@@ -223,7 +223,7 @@ def train(train_loader, model, criterion, optimizer, idx, flip=True):
         data_time.update(time.time() - end)
 
         input_var = torch.autograd.Variable(inputs.cuda())
-        target_var = torch.autograd.Variable(target.cuda(async=True))
+        target_var = torch.autograd.Variable(target.cuda(non_blocking=True))
 
         # compute output
         output = model(input_var)
@@ -293,7 +293,7 @@ def validate(val_loader, model, criterion, num_classes, idx, save_result_dir, me
 
         if anno_type != 'none':
 
-            target = target.cuda(async=True)
+            target = target.cuda(non_blocking=True)
             target_var = torch.autograd.Variable(target)
 
         input_var = torch.autograd.Variable(inputs.cuda())
@@ -497,3 +497,4 @@ if __name__ == '__main__':
                         help='save heatmap as .npy file')
 
     main(parser.parse_args())
+    


### PR DESCRIPTION
__async__ is a reserved word in Python 3.7 and later.  To fix this pytorch/pytorch#4999 changed __cuda(async=True)__ to __cuda(non_blocking=True)__ so this PR tracks with that change.  That fix landed in PyTourch 0.4.1.